### PR TITLE
Fix student/teacher dashboard UX and Qwen model swap

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -1407,11 +1407,12 @@ def get_messages(conversation_id):
         # Resolve RAG thread_id and filename for this conversation (for correct chat context and preamble)
         thread_id = None
         uploaded_filename = None
+        num_pages = None
         try:
             from app.models.database_models import RAGThread
             db = get_db()
             prefix = f"user_{user_id}_conv_{conversation_id}_"
-            row = db.query(RAGThread.thread_id, RAGThread.filename).filter(
+            row = db.query(RAGThread.thread_id, RAGThread.filename, RAGThread.num_pages).filter(
                 RAGThread.user_id == user_id,
                 RAGThread.thread_id.like(prefix + "%"),
                 RAGThread.has_document == True,
@@ -1419,12 +1420,14 @@ def get_messages(conversation_id):
             if row:
                 thread_id = row[0] if isinstance(row, (tuple, list)) else row.thread_id
                 uploaded_filename = (row[1] if isinstance(row, (tuple, list)) and len(row) > 1 else getattr(row, 'filename', None)) or None
+                num_pages = (row[2] if isinstance(row, (tuple, list)) and len(row) > 2 else getattr(row, 'num_pages', None))
         except Exception:
             pass
         return jsonify({
             'messages': messages,
             'thread_id': thread_id,
             'uploaded_filename': uploaded_filename,
+            'num_pages': num_pages,
         })
     except Exception as e:
         logger.error(f"Error retrieving messages: {str(e)}")

--- a/app/utils/llm_factory.py
+++ b/app/utils/llm_factory.py
@@ -10,7 +10,8 @@ from app.config import Config
 from app.utils.llm_models import (
     get_default_model_for_provider,
     is_valid_model_for_provider,
-    get_model_ids_for_provider
+    get_model_ids_for_provider,
+    get_groq_max_completion_tokens,
 )
 from app.utils.encryption import decrypt_api_key
 from app.utils.llm_gateway import wrap_llm_with_telemetry
@@ -131,10 +132,19 @@ def get_chat_model(user_id: Optional[int] = None, **kwargs):
             else:
                 # Fallback to hardcoded default
                 model_to_use = get_default_model_for_provider(active_provider)
+
+        # Groq retired qwen/qwen3-32b (Jul 17 2026); map to current Qwen replacement.
+        if (model_to_use or "").strip().lower() == "qwen/qwen3-32b":
+            logger.warning(
+                "Model qwen/qwen3-32b is retired on Groq; using qwen/qwen3.6-27b instead"
+            )
+            model_to_use = "qwen/qwen3.6-27b"
         
         # Override with explicit model_name if provided
         if kwargs.get('model_name'):
             model_to_use = kwargs['model_name']
+            if (model_to_use or "").strip().lower() == "qwen/qwen3-32b":
+                model_to_use = "qwen/qwen3.6-27b"
         
         # Create LLM instance
         logger.info(f"Creating LLM with provider={active_provider.lower()}, model={model_to_use}, has_api_key={bool(api_key)}")
@@ -312,6 +322,15 @@ def create_llm(
         model = model_name or os.getenv('GROQ_MODEL', 'openai/gpt-oss-120b')
         temp = temperature if temperature is not None else float(os.getenv('GROQ_TEMPERATURE', '0.5'))
         max_toks = max_tokens if max_tokens is not None else int(os.getenv('GROQ_MAX_TOKENS', '1024'))
+        model_cap = get_groq_max_completion_tokens(model)
+        if max_toks > model_cap:
+            logger.warning(
+                "Clamping Groq max_tokens from %s to %s for model %s",
+                max_toks,
+                model_cap,
+                model,
+            )
+            max_toks = model_cap
         time_out = timeout if timeout is not None else int(os.getenv('GROQ_TIMEOUT', '60'))
         
         groq_kwargs = {

--- a/app/utils/llm_gateway.py
+++ b/app/utils/llm_gateway.py
@@ -163,7 +163,8 @@ def extract_token_counts_from_chunk(chunk: BaseMessageChunk) -> tuple[Optional[i
 _DEFAULT_MODEL_PRICING: dict[tuple[str, str], tuple[float, float]] = {
     ("groq", "llama-3.3-70b-versatile"): (0.59, 0.79),
     ("groq", "llama-3.1-8b-instant"): (0.05, 0.08),
-    ("groq", "qwen/qwen3-32b"): (0.29, 0.59),
+    ("groq", "qwen/qwen3.6-27b"): (0.60, 3.00),
+    ("groq", "qwen/qwen3-32b"): (0.29, 0.59),  # retired on Groq; kept for historical telemetry
     ("groq", "mixtral-8x7b-32768"): (0.24, 0.24),
     ("openai", "gpt-4o"): (2.5, 10.0),
     ("openai", "gpt-4o-mini"): (0.15, 0.6),

--- a/app/utils/llm_models.py
+++ b/app/utils/llm_models.py
@@ -17,7 +17,7 @@ GROQ_MODELS = {
         {"id": "llama-3-8b-8192", "name": "Llama 3 8B 8192"},
     ],
     "qwen": [
-        {"id": "qwen/qwen3-32b", "name": "Qwen3 32B"},
+        {"id": "qwen/qwen3.6-27b", "name": "Qwen3.6 27B"},
     ],
 }
 
@@ -32,6 +32,30 @@ OPENAI_MODELS = [
 
 # All Groq models (flattened)
 ALL_GROQ_MODELS = [model for model_list in GROQ_MODELS.values() for model in model_list]
+
+# Per-model max completion tokens (Groq docs). Requests above these return 400.
+GROQ_MODEL_MAX_COMPLETION_TOKENS = {
+    "qwen/qwen3.6-27b": 16384,
+    "openai/gpt-oss-120b": 65536,
+    "openai/gpt-oss-20b": 65536,
+    "llama-3.3-70b-versatile": 32768,
+    "llama-3.1-8b-instant": 131072,
+    "llama-3.1-70b-versatile": 32768,
+}
+GROQ_DEFAULT_MAX_COMPLETION_TOKENS = 8192
+
+
+def get_groq_max_completion_tokens(model_id: str) -> int:
+    """Return Groq max_tokens ceiling for a model (completion limit, not context)."""
+    if not model_id:
+        return GROQ_DEFAULT_MAX_COMPLETION_TOKENS
+    key = model_id.strip().lower()
+    if key in GROQ_MODEL_MAX_COMPLETION_TOKENS:
+        return GROQ_MODEL_MAX_COMPLETION_TOKENS[key]
+    # Conservative default for unknown / preview models
+    if "qwen" in key:
+        return 16384
+    return GROQ_DEFAULT_MAX_COMPLETION_TOKENS
 
 
 def get_groq_available_models() -> dict:

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -510,7 +510,7 @@
                                     <option value="llama-3-8b-8192">Llama 3 8B 8192</option>
                                 </optgroup>
                                 <optgroup label="Qwen Models">
-                                    <option value="qwen/qwen3-32b">Qwen3 32B</option>
+                                    <option value="qwen/qwen3.6-27b">Qwen3.6 27B</option>
                                 </optgroup>
                             </select>
                         </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -534,52 +534,13 @@
               <h2
                 class="text-4xl lg:text-5xl font-bold text-white mb-6 font-display leading-tight"
               >
-                Welcome Back to <span class="gradient-text">Your Future</span>
+                Welcome to Iqbal AI
               </h2>
 
               <p class="text-xl text-primary-100 mb-10 leading-relaxed">
                 Continue your journey with personalized AI learning. Access
                 cutting-edge courses, projects, and career guidance.
               </p>
-            </div>
-
-            <!-- Features Grid -->
-            <div class="grid grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-              <div class="glass-dark rounded-xl p-5 border border-white/10">
-                <div
-                  class="w-12 h-12 rounded-lg bg-gradient-to-br from-primary-500 to-primary-600 flex items-center justify-center mb-4"
-                >
-                  <i class="fas fa-brain text-white text-lg"></i>
-                </div>
-                <h3 class="text-white font-semibold mb-2">AI Mentor</h3>
-                <p class="text-primary-200 text-sm">
-                  Personalized learning paths
-                </p>
-              </div>
-
-              <div class="glass-dark rounded-xl p-5 border border-white/10">
-                <div
-                  class="w-12 h-12 rounded-lg bg-gradient-to-br from-accent-500 to-accent-600 flex items-center justify-center mb-4"
-                >
-                  <i class="fas fa-chart-line text-white text-lg"></i>
-                </div>
-                <h3 class="text-white font-semibold mb-2">Progress Tracking</h3>
-                <p class="text-primary-200 text-sm">
-                  Real-time skill analytics
-                </p>
-              </div>
-
-              <div class="glass-dark rounded-xl p-5 border border-white/10">
-                <div
-                  class="w-12 h-12 rounded-lg bg-gradient-to-br from-success-500 to-success-600 flex items-center justify-center mb-4"
-                >
-                  <i class="fas fa-certificate text-white text-lg"></i>
-                </div>
-                <h3 class="text-white font-semibold mb-2">Certifications</h3>
-                <p class="text-primary-200 text-sm">
-                  Industry-recognized credentials
-                </p>
-              </div>
             </div>
 
           </div>

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -6464,8 +6464,9 @@
       }
 
       function stopTextToSpeechSession() {
-        if (window.speechSynthesis && speechSynthesis.speaking) {
-          speechSynthesis.cancel();
+        const synth = speechSynthesis || window.speechSynthesis;
+        if (synth && synth.speaking) {
+          synth.cancel();
         }
         isTextToSpeechActive = false;
         const speakerBtn = document.getElementById('speakerBtn');

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -3043,13 +3043,13 @@
           </div>
         </div>
 
-      <!-- View and Manage Lesson Button -->
+      <!-- My Lessons Button -->
       <div class="px-4 mb-4">
         <button id="lessonsTabBtn" onclick="showMyLessonsPage()"
           class="w-full py-2.5 px-3 flex items-center justify-between text-gray-700 bg-primary-50 hover:bg-primary-100 rounded-lg transition-all duration-200 active-tab">
           <div class="flex items-center gap-3">
             <i class="fas fa-book-open w-5 text-primary-500"></i>
-            <span class="font-medium sb-hide-when-collapsed">View and Manage Lesson</span>
+            <span class="font-medium sb-hide-when-collapsed">My Lessons</span>
           </div>
           <i class="fas fa-chevron-right text-gray-400 text-sm sb-hide-when-collapsed"></i>
         </button>
@@ -3114,13 +3114,13 @@
         </button>
       </div>
 
-      <!-- View and Manage Lesson Button -->
+      <!-- My Lessons Button -->
       <div class="px-4 mb-4">
         <button id="lessonsTabBtn" onclick="showMyLessonsPage(); toggleMobileSidebar();"
           class="w-full py-2.5 px-3 flex items-center justify-between text-gray-700 bg-primary-50 hover:bg-primary-100 rounded-lg transition-all duration-200 active-tab">
           <div class="flex items-center gap-3">
             <i class="fas fa-book-open w-5 text-primary-500"></i>
-            <span class="font-medium">View and Manage Lesson</span>
+            <span class="font-medium">My Lessons</span>
           </div>
           <i class="fas fa-chevron-right text-gray-400 text-sm"></i>
         </button>
@@ -3755,7 +3755,7 @@
           }
         });
 
-        // Always land on View and Manage Lesson immediately on login/load.
+        // Always land on My Lessons immediately on login/load.
         // Load sidebar chat history in the background so a slow/failed
         // conversations request cannot leave the user on an empty chat.
         setStudentActiveView('lessons');

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -3043,13 +3043,13 @@
           </div>
         </div>
 
-      <!-- View Lessons Button -->
+      <!-- View and Manage Lesson Button -->
       <div class="px-4 mb-4">
         <button id="lessonsTabBtn" onclick="showMyLessonsPage()"
           class="w-full py-2.5 px-3 flex items-center justify-between text-gray-700 bg-primary-50 hover:bg-primary-100 rounded-lg transition-all duration-200 active-tab">
           <div class="flex items-center gap-3">
             <i class="fas fa-book-open w-5 text-primary-500"></i>
-            <span class="font-medium sb-hide-when-collapsed">View Lessons</span>
+            <span class="font-medium sb-hide-when-collapsed">View and Manage Lesson</span>
           </div>
           <i class="fas fa-chevron-right text-gray-400 text-sm sb-hide-when-collapsed"></i>
         </button>
@@ -3114,13 +3114,13 @@
         </button>
       </div>
 
-      <!-- View Lessons Button -->
+      <!-- View and Manage Lesson Button -->
       <div class="px-4 mb-4">
         <button id="lessonsTabBtn" onclick="showMyLessonsPage(); toggleMobileSidebar();"
           class="w-full py-2.5 px-3 flex items-center justify-between text-gray-700 bg-primary-50 hover:bg-primary-100 rounded-lg transition-all duration-200 active-tab">
           <div class="flex items-center gap-3">
             <i class="fas fa-book-open w-5 text-primary-500"></i>
-            <span class="font-medium">View Lessons</span>
+            <span class="font-medium">View and Manage Lesson</span>
           </div>
           <i class="fas fa-chevron-right text-gray-400 text-sm"></i>
         </button>
@@ -3184,41 +3184,13 @@
         <div class="w-8"></div>
       </div>
 
-      <!-- Chat Area -->
+      <!-- Chat Area — default to lessons list on login (not empty chat) -->
       <section id="chatArea" class="flex-1 p-4 md:p-6 overflow-y-auto custom-scrollbar">
         <div id="chatMessages" class="w-full max-w-6xl mx-auto px-2 md:px-4 space-y-3 md:space-y-6">
-          <!-- Welcome message - AI on RIGHT side -->
-          <div class="chat-message assistant animate-fade-in">
-            <div class="chat-message-avatar">
-              <img src="{{ url_for('static', filename='teacher/assets/midLogo.png') }}" alt="AI Assistant">
-            </div>
-            <div class="chat-message-content">
-              <h4 class="font-display font-semibold text-surface-900 mb-2">Welcome to Student Portal!</h4>
-              <p class="text-surface-700">You can explore and learn from:</p>
-              <ul class="mt-2 space-y-1 text-surface-600">
-                <li class="flex items-start gap-2">
-                  <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
-                  <span>All available lessons</span>
-                </li>
-                <li class="flex items-start gap-2">
-                  <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
-                  <span>Course materials and resources</span>
-                </li>
-                <li class="flex items-start gap-2">
-                  <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
-                  <span>Learning objectives and assessments</span>
-                </li>
-                <li class="flex items-start gap-2">
-                  <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
-                  <span>Track your learning progress</span>
-                </li>
-              </ul>
-              <div class="mt-4 p-3 bg-primary-50 rounded-lg border border-primary-100">
-                <p class="text-primary-700 text-sm">
-                  <i class="fas fa-lightbulb mr-2"></i>
-                  <strong>Tip:</strong> Click "View Lessons" to see all available course materials!
-                </p>
-              </div>
+          <div class="max-w-6xl mx-auto">
+            <div class="bg-gradient-to-r from-primary-500 to-primary-600 text-white rounded-lg shadow-lg p-4 md:p-6 mb-6 md:mb-8">
+              <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View and Manage Lesson</h1>
+              <p class="text-primary-100 text-sm md:text-base">Loading lessons...</p>
             </div>
           </div>
         </div>
@@ -3232,8 +3204,8 @@
       </section>
 
 
-      <!-- Modern ChatGPT-style Bottom Chat Input Area - Mobile Optimized -->
-      <div id="chatInputArea" class="sticky bottom-0 bg-white z-30 py-2 md:py-4 border-t border-gray-200 shadow-lg md:shadow-xl transition-all duration-300">
+      <!-- Chat input hidden until a lesson chat is opened -->
+      <div id="chatInputArea" class="sticky bottom-0 bg-white z-30 py-2 md:py-4 border-t border-gray-200 shadow-lg md:shadow-xl transition-all duration-300" style="display: none;">
         <div class="max-w-4xl mx-auto px-2 md:px-4">
           <!-- Voice Input Status (hidden by default) -->
           <div id="voiceStatus" class="voice-status rounded-lg p-3 mb-3 hidden bg-blue-50 border border-blue-200 animate-pulse">
@@ -3527,8 +3499,32 @@
             <img src="{{ url_for('static', filename='teacher/assets/midLogo.png') }}" alt="AI Assistant">
           </div>
           <div class="chat-message-content">
-            <h4 class="font-display font-semibold text-surface-900 mb-2">📚 Welcome to Learning</h4>
-            <p class="text-surface-700">I'm here to help you learn! Ask me questions about your lessons, clarify concepts, or dive deeper into any topic. Select a lesson to get started or ask me anything!</p>
+            <h4 class="font-display font-semibold text-surface-900 mb-2">Welcome to Student Portal!</h4>
+            <p class="text-surface-700">You can explore and learn from:</p>
+            <ul class="mt-2 space-y-1 text-surface-600">
+              <li class="flex items-start gap-2">
+                <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
+                <span>All available lessons</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
+                <span>Course materials and resources</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
+                <span>Learning objectives and assessments</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <i class="fas fa-check-circle text-success-500 mt-0.5"></i>
+                <span>Track your learning progress</span>
+              </li>
+            </ul>
+            <div class="mt-4 p-3 bg-primary-50 rounded-lg border border-primary-100">
+              <p class="text-primary-700 text-sm">
+                <i class="fas fa-lightbulb mr-2"></i>
+                <strong>Tip:</strong> Open a lesson from View and Manage Lesson, then tap Ask Question to chat about it.
+              </p>
+            </div>
           </div>
         </div>
       `;
@@ -3690,12 +3686,12 @@
 
         chatMessages.innerHTML = `
         <div class="max-w-2xl mx-auto p-8 h-full flex flex-col items-center justify-center text-center">
-          <i class="fas fa-comments text-6xl text-gray-300 mb-4"></i>
-          <h2 class="text-2xl font-bold text-gray-700 mb-2">No conversations yet</h2>
-          <p class="text-gray-500 mb-6">Start your first chat by clicking the button below</p>
-          <button onclick="startNewChat()" class="bg-primary-600 text-white px-6 py-2.5 rounded-lg hover:bg-primary-700 transition-colors font-medium">
-            <i class="fas fa-plus mr-2"></i>
-            Start New Chat
+          <i class="fas fa-book-open text-6xl text-gray-300 mb-4"></i>
+          <h2 class="text-2xl font-bold text-gray-700 mb-2">No active lesson chat</h2>
+          <p class="text-gray-500 mb-6">Open a lesson from View and Manage Lesson, then use Ask Question to start chatting.</p>
+          <button onclick="showMyLessonsPage()" class="bg-primary-600 text-white px-6 py-2.5 rounded-lg hover:bg-primary-700 transition-colors font-medium">
+            <i class="fas fa-book-open mr-2"></i>
+            View and Manage Lesson
           </button>
         </div>
       `;
@@ -3759,23 +3755,23 @@
           }
         });
 
-        // Initialize chat state per specification #6
-        // If chat history exists, load most recent chat
-        // If no chats, show empty state
-        await initializeChatState();
-        const preferredView = getStudentActiveView();
-        if (preferredView === 'chat' && currentChatId) {
-          showChatTab();
-        } else {
-          showMyLessonsPage();
-        }
+        // Always land on View and Manage Lesson immediately on login/load.
+        // Load sidebar chat history in the background so a slow/failed
+        // conversations request cannot leave the user on an empty chat.
+        setStudentActiveView('lessons');
+        showMyLessonsPage();
+        initializeChatState().catch(function (err) {
+          console.error('Failed to initialize student chat sidebar', err);
+        });
 
         // Setup textarea auto-resize and validation
         const textarea = document.getElementById('messageInput');
-        textarea.addEventListener('input', function () {
-          autoResizeTextarea(this);
-          updateSendButton();
-        });
+        if (textarea) {
+          textarea.addEventListener('input', function () {
+            autoResizeTextarea(this);
+            updateSendButton();
+          });
+        }
 
         // Initialize speech recognition if available
         if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
@@ -3810,9 +3806,12 @@
             alert('Speech recognition error: ' + event.error);
           };
         } else {
-          document.getElementById('micBtn').disabled = true;
-          document.getElementById('micBtn').title = 'Speech recognition not supported';
-          document.getElementById('micBtn').innerHTML = '<i class="fas fa-microphone-slash"></i>';
+          const micBtn = document.getElementById('micBtn');
+          if (micBtn) {
+            micBtn.disabled = true;
+            micBtn.title = 'Speech recognition not supported';
+            micBtn.innerHTML = '<i class="fas fa-microphone-slash"></i>';
+          }
         }
 
         // Initialize speech synthesis
@@ -4533,7 +4532,7 @@
           chatMessages.innerHTML = `
           <div class="max-w-6xl mx-auto">
             <div class="bg-gradient-to-r from-primary-500 to-primary-600 text-white rounded-lg shadow-lg p-4 md:p-6 mb-6 md:mb-8">
-              <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View Lessons</h1>
+              <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View and Manage Lesson</h1>
               <p class="text-primary-100 text-sm md:text-base">Loading lessons...</p>
             </div>
           </div>
@@ -4609,7 +4608,7 @@
       <div class="bg-gradient-to-r from-primary-500 to-primary-600 text-white rounded-lg shadow-lg p-4 md:p-6 mb-6 md:mb-8">
         <div class="flex flex-col gap-4">
           <div>
-            <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View Lessons</h1>
+            <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View and Manage Lesson</h1>
             <p class="text-primary-100 text-sm md:text-base">Explore and learn from all available courses</p>
           </div>
         </div>
@@ -4658,6 +4657,12 @@
                 </td>
                 <td data-label="Actions">
                   <div class="lesson-actions">
+                    <button class="action-btn view-btn" title="View lesson" onclick="viewLesson('${lesson.id}')">
+                      <i class="fas fa-eye"></i>
+                    </button>
+                    <button class="action-btn" style="background: #dcfce7; color: #166534;" title="Ask questions about this lesson" onclick="chatWithLesson('${lesson.id}')">
+                      <i class="fas fa-comment-dots"></i>
+                    </button>
                     <button class="action-btn" style="background: #dbeafe; color: #1e40af;" title="Download PPT" onclick="downloadLessonPPT('${lesson.id}')">
                       <i class="fas fa-file-powerpoint"></i>
                     </button>
@@ -4714,6 +4719,38 @@
 
 
       // Lesson actions
+      async function chatWithLesson(lessonId) {
+        if (!lessonId) {
+          showToast('No lesson selected', 'error', 2000);
+          return;
+        }
+        window.currentViewLessonId = lessonId;
+        // Ensure lesson is in cache (may need fetch if not on current page)
+        let index = findLessonById(lessonId);
+        if (index === -1) {
+          try {
+            const response = await fetch(`/api/lessons/lesson/${lessonId}`, {
+              method: 'GET',
+              credentials: 'include'
+            });
+            const data = await response.json().catch(function () { return {}; });
+            if (response.ok && data && data.success && data.lesson) {
+              const lesson = data.lesson;
+              _studentLessonsCache.push({
+                id: lesson.id,
+                title: lesson.title || 'Lesson',
+                subject: lesson.focus_area || lesson.subject || 'Subject',
+                grade: lesson.grade_level || lesson.grade || 'N/A',
+                content: lesson.content || lesson.body || lesson.original_content || ''
+              });
+            }
+          } catch (e) {
+            console.warn('chatWithLesson: failed to prefetch lesson', e);
+          }
+        }
+        await openLessonChat();
+      }
+
       function viewLesson(lessonId) {
         try {
           console.log('🔍 viewLesson called with lessonId:', lessonId, 'type:', typeof lessonId);
@@ -6343,24 +6380,28 @@
         })();
 
         function applyLocalDeletion() {
-          chatHistory = chatHistory.filter(function (chat) { return String(chat.id) !== String(currentChatMenuId); });
+          const deletedId = String(currentChatMenuId);
+          chatHistory = chatHistory.filter(function (chat) { return String(chat.id) !== deletedId; });
+
+          // Drop lesson binding for deleted chat
+          try {
+            const raw = localStorage.getItem('Student_chat_lesson_bindings') || '{}';
+            const map = JSON.parse(raw || '{}') || {};
+            if (map[deletedId] != null) {
+              delete map[deletedId];
+              localStorage.setItem('Student_chat_lesson_bindings', JSON.stringify(map));
+            }
+          } catch (e) {}
 
           saveChatThreads();
-          renderChatSidebar(); // Update sidebar after deletion
+          renderChatSidebar();
 
-          if (String(currentChatId) === String(currentChatMenuId)) {
-            // If deleting active chat, switch to first available
-            if (chatHistory.length > 0) {
-              loadChat(chatHistory[0].id);
-            } else {
-              startNewChat();
-            }
-          }
-
-          // Remove from UI (backup in case renderChatSidebar didn't catch it)
-          const chatElement = document.querySelector(`[onclick="loadChat('${currentChatMenuId}')\"]`);
-          if (chatElement) {
-            chatElement.remove();
+          if (String(currentChatId) === deletedId) {
+            currentChatId = null;
+            window.currentLessonContext = null;
+            window.currentLessonQAId = null;
+            // Return to lessons list; do not leave an empty chat open.
+            showMyLessonsPage();
           }
         }
 
@@ -6483,7 +6524,7 @@
         }
 
         if (!lessonId) {
-          showToast('No lesson context', 'error');
+          showToast('Open a lesson first, then Ask Question to chat about it.', 'warning', 3500);
           console.warn('[StudentDash] sendLessonQAMessageInMain called without lessonId', {
             currentLessonQAId: window.currentLessonQAId,
             currentLessonContext: window.currentLessonContext
@@ -7233,7 +7274,12 @@
           } catch (e) {
             console.error('Failed to reset chat conversation', e);
           }
-          startNewChat();
+          chatHistory = chatHistory.filter(function (c) { return String(c.id) !== String(currentChatId); });
+          currentChatId = null;
+          window.currentLessonContext = null;
+          window.currentLessonQAId = null;
+          renderChatSidebar();
+          showMyLessonsPage();
         }
       }
 

--- a/templates/teacher_dashboard.html
+++ b/templates/teacher_dashboard.html
@@ -3134,19 +3134,8 @@
         </div>
       </div>
 
-      <!-- Create New Lesson Button (Replaces New Chat) -->
-      <div class="p-4">
-        <!-- <button onclick="showCreateLessonWizard()" 
-                class="w-full py-3 px-4 flex items-center gap-3 bg-gradient-to-r from-success-500 to-success-600 text-white rounded-xl hover:from-success-600 hover:to-success-700 transition-all duration-200 shadow-md hover:shadow-lg">
-          <div class="w-5 h-5 rounded-md bg-white/20 flex items-center justify-center">
-            <i class="fas fa-plus text-xs"></i>
-          </div>
-          <span class="font-medium">Create New Lesson</span>
-        </button> -->
-      </div>
-
       <!-- My Lessons Button -->
-      <div class="px-4 mb-4">
+      <div class="px-4 mb-4 mt-4">
         <button id="lessonsTabBtn" onclick="showMyLessonsPage()"
           class="w-full py-2.5 px-3 flex items-center justify-between text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200">
           <div class="flex items-center gap-3">
@@ -5550,6 +5539,8 @@
                 pendingConversationId = conversationId;
                 window._ingestPendingThreadId = pendingThreadId;
                 window._ingestCompletedSuccessfully = true;
+                if (!window._createLessonMeta) window._createLessonMeta = {};
+                window._createLessonMeta.numPages = statusData.num_pages || statusData.pages || statusData.documents || null;
                 break;
               }
               if (statusData.status === 'failed' || statusData.status === 'failure' || statusData.state === 'FAILURE') {
@@ -5570,12 +5561,16 @@
             if (conversationId != null) {
               window.currentRAGConversationId = conversationId;
               try { localStorage.setItem('teacher_currentRAGConversationId', String(conversationId)); } catch (e) {}
-              if (window._createLessonMeta) {
-                window._createLessonMeta.conversationId = conversationId;
-                window._createLessonMeta.threadId = threadId;
-              }
+              if (!window._createLessonMeta) window._createLessonMeta = {};
+              window._createLessonMeta.conversationId = conversationId;
+              window._createLessonMeta.threadId = threadId;
             }
-            showCreateLessonUploadComplete(fileName, fileSize, lessonTitle, lessonContext, lessonSubject, lessonGrade);
+            if (!window._createLessonMeta) window._createLessonMeta = {};
+            if (window._createLessonMeta.numPages == null) {
+              window._createLessonMeta.numPages = data.num_pages || data.pages || data.documents || null;
+            }
+            // Auto-redirect into chat after successful processing (no manual Continue click).
+            finalizeCreateLesson(fileName, fileSize, lessonTitle, lessonContext, lessonSubject, lessonGrade);
           } else {
             // Best-effort cleanup for cancelled thread so it cannot be used accidentally.
             if (window._ingestCancelRequested && pendingThreadId) {
@@ -5834,9 +5829,47 @@ Last Updated: ${new Date().toLocaleDateString()}`;
         return plainContent;
       }
 
+      // Build the PDF upload success bubble (summary + action options).
+      function buildPDFUploadSuccessMessage(opts) {
+        opts = opts || {};
+        const fileName = opts.fileName || opts.filename || 'document';
+        const lessonTitle = opts.lessonTitle || opts.title || fileName.replace(/\.pdf$/i, '');
+        const lessonSubject = opts.lessonSubject || opts.subject || '';
+        const lessonGrade = opts.lessonGrade || opts.grade || '';
+        const lessonContext = opts.lessonContext || opts.context || '';
+        const fileSize = opts.fileSize || opts.size || null;
+        const fileSizeMB = fileSize != null ? (Number(fileSize) / (1024 * 1024)).toFixed(2) : null;
+        let pages = opts.pages || opts.numPages || opts.num_pages || null;
+        if (pages == null && fileSize != null) {
+          pages = Math.ceil(Number(fileSize) / 50000);
+        }
+
+        let details = '<strong>PDF Details:</strong><br>';
+        details += '• <strong>PDF Name:</strong> ' + String(fileName).replace(/[<>]/g, '') + '<br>';
+        if (lessonTitle) details += '• <strong>Title:</strong> ' + String(lessonTitle).replace(/[<>]/g, '') + '<br>';
+        if (lessonSubject) details += '• <strong>Subject:</strong> ' + String(lessonSubject).replace(/[<>]/g, '') + '<br>';
+        if (lessonGrade) details += '• <strong>Grade:</strong> ' + String(lessonGrade).replace(/[<>]/g, '') + '<br>';
+        if (fileSizeMB != null) details += '• <strong>File Size:</strong> ' + fileSizeMB + ' MB<br>';
+        if (pages != null) details += '• <strong>Pages:</strong> ' + pages + '<br>';
+        if (lessonContext) details += '• <strong>Context:</strong> ' + String(lessonContext).replace(/[<>]/g, '') + '<br>';
+
+        return '✅ <strong>Successfully uploaded "' + String(fileName).replace(/[<>"]/g, '') + '"!</strong><br><br>' +
+          details + '<br>' +
+          '<strong>📝 What would you like to do?</strong><br>' +
+          'Type one of these commands:<br>' +
+          '• "create a lesson" - Generate a lesson from this PDF<br>' +
+          '• "summarize" - Get a brief summary<br>' +
+          '• "ask me questions" - Generate quiz questions<br>' +
+          '• Or ask your own questions about the content!';
+      }
+
       // Finalization function - NO AUTO-SAVE
       function finalizeCreateLesson(fileName, fileSize, lessonTitle, lessonContext, lessonSubject, lessonGrade) {
         closeCreateLessonModal();
+
+        const numPages = (window._createLessonMeta && window._createLessonMeta.numPages != null)
+          ? window._createLessonMeta.numPages
+          : Math.ceil(fileSize / 50000);
 
         // Store PDF metadata only. Do NOT set currentLessonMarkdown to the template here –
         // the actual lesson comes from the AI when the user says "create a lesson" in chat and is stored by RAG.
@@ -5848,6 +5881,7 @@ Last Updated: ${new Date().toLocaleDateString()}`;
           context: lessonContext,
           subject: lessonSubject,
           grade: lessonGrade,
+          numPages: numPages,
           createdBy: "Good",
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -5861,6 +5895,8 @@ Last Updated: ${new Date().toLocaleDateString()}`;
         // Save to localStorage so it persists across tab switches
         savePDFDataToStorage();
 
+        showToast(`✅ PDF "${lessonTitle}" uploaded successfully!`, 'success', 4000);
+
         // Enable chat tab and switch to the NEW backend conversation (do not start a client-side chat)
         enableChatTab();
         showChatTab();
@@ -5868,13 +5904,31 @@ Last Updated: ${new Date().toLocaleDateString()}`;
         // Prefer the conversation/thread created for THIS upload, fall back to global if needed
         var metaConvId = (window._createLessonMeta && window._createLessonMeta.conversationId) || null;
         var newConvId = metaConvId != null ? metaConvId : window.currentRAGConversationId;
+        var successHtml = buildPDFUploadSuccessMessage({
+          fileName: fileName,
+          lessonTitle: lessonTitle,
+          lessonSubject: lessonSubject,
+          lessonGrade: lessonGrade,
+          lessonContext: lessonContext,
+          fileSize: fileSize,
+          pages: numPages
+        });
+
         if (newConvId != null) {
           setBackendConversationTitle(newConvId, lessonTitle);
           loadChatHistoryFromBackend().then(function () {
             return loadChatPromise(newConvId);
+          }).then(function () {
+            // Preamble already shows PDF summary + action bullets from currentPDFData.
+            // Add a single user marker; avoid duplicating the assistant success bubble.
+            addUserMessage('📚 Uploaded PDF: ' + lessonTitle);
           }).catch(function (e) { console.error('Error switching to new conversation', e); });
         } else {
           startNewChat();
+          addUserMessage('📚 Uploaded PDF: ' + lessonTitle);
+          setTimeout(function () {
+            addAssistantMessage(successHtml);
+          }, 300);
         }
       }
 
@@ -5933,31 +5987,14 @@ Last Updated: ${new Date().toLocaleDateString()}`;
         if (lessons.length === 0) {
           chatMessages.innerHTML = `
       <div class="max-w-6xl mx-auto p-6">
-        <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
-          <div>
-            <h1 class="text-2xl font-bold text-gray-900 mb-2">View &amp; Manage All Lessons.</h1>
-            <p class="text-gray-600">View and manage all your created lessons</p>
-          </div>
-          
-          <!-- Action Buttons moved to top right -->
-          <div class="flex gap-3">
-            <button onclick="showCreateLessonWizard()" 
-                    class="bg-primary-600 text-white px-5 py-2.5 rounded-lg hover:bg-primary-700 transition-colors font-medium inline-flex items-center gap-2 whitespace-nowrap">
-              <i class="fas fa-plus"></i>
-              Create New Lesson
-            </button>
-          </div>
+        <div class="mb-8">
+          <h1 class="text-2xl font-bold text-gray-900 mb-2">View &amp; Manage All Lessons</h1>
         </div>
         
         <div class="text-center py-12">
           <i class="fas fa-book-open text-6xl text-gray-300 mb-4"></i>
           <h3 class="text-xl font-semibold text-gray-700 mb-2">No lessons yet</h3>
-          <p class="text-gray-500 mb-6">You haven't created any lessons. Start by creating your first lesson!</p>
-          <button onclick="showCreateLessonWizard()" 
-                  class="bg-primary-600 text-white px-6 py-2.5 rounded-lg hover:bg-primary-700 transition-colors font-medium">
-            <i class="fas fa-plus mr-2"></i>
-            Create New Lesson
-          </button>
+          <p class="text-gray-500">You haven't created any lessons yet. Use the green button in the sidebar to get started.</p>
         </div>
       </div>
     `;
@@ -6005,8 +6042,7 @@ Last Updated: ${new Date().toLocaleDateString()}`;
       <div class="bg-gradient-to-r from-primary-500 to-primary-600 text-white rounded-lg shadow-lg p-4 md:p-6 mb-6 md:mb-8">
         <div class="flex flex-col gap-4">
           <div>
-            <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View &amp; Manage All Lessons.</h1>
-            <p class="text-primary-100 text-sm md:text-base">View and manage all your created lessons</p>
+            <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">View &amp; Manage All Lessons</h1>
           </div>
           
           <!-- Action Buttons (none for now on teacher dashboard) -->
@@ -7908,15 +7944,25 @@ Last Updated: ${new Date().toLocaleDateString()}`;
           return !isNaN(n) && String(n) === String(chatId);
         })();
 
-        function renderRAGPreamble(uploadedFilename) {
+        function renderRAGPreamble(uploadedFilename, extra) {
+          extra = extra || {};
+          const pdfMeta = (typeof currentPDFData !== 'undefined' && currentPDFData) ? currentPDFData : {};
+          const successHtml = buildPDFUploadSuccessMessage({
+            fileName: uploadedFilename || pdfMeta.fileName || 'document',
+            lessonTitle: pdfMeta.title || null,
+            lessonSubject: pdfMeta.subject || null,
+            lessonGrade: pdfMeta.grade || null,
+            lessonContext: pdfMeta.context || null,
+            fileSize: pdfMeta.fileSize || null,
+            pages: extra.numPages != null ? extra.numPages : (pdfMeta.numPages || null)
+          });
           chatMessages.innerHTML = `
         <div class="chat-message assistant animate-fade-in">
           <div class="chat-message-avatar">
             <img src="{{ url_for('static', filename='teacher/assets/midLogo.png') }}" alt="AI Assistant" onerror="this.onerror=null; this.src=''; this.innerHTML='<i class=\\'fas fa-graduation-cap\\'></i>'; this.classList.add('flex', 'items-center', 'justify-center')">
           </div>
           <div class="chat-message-content">
-            ✅ <strong>Successfully uploaded \u201C${String(uploadedFilename || 'document').replace(/["<>]/g, '')}\u201D.</strong><br><br>
-            You can ask questions about this document below.
+            ${successHtml}
           </div>
         </div>
         `;
@@ -7927,7 +7973,9 @@ Last Updated: ${new Date().toLocaleDateString()}`;
           const prependRAG = options.prependRAGPreamble && options.uploadedFilename !== undefined;
           chatMessages.innerHTML = '';
           if (prependRAG) {
-            renderRAGPreamble(options.uploaded_filename || options.uploadedFilename || 'document');
+            renderRAGPreamble(options.uploaded_filename || options.uploadedFilename || 'document', {
+              numPages: options.num_pages != null ? options.num_pages : options.numPages
+            });
           }
           let effectiveMessages = Array.isArray(messages) ? messages.slice() : [];
 
@@ -7993,6 +8041,8 @@ Last Updated: ${new Date().toLocaleDateString()}`;
               opts.prependRAGPreamble = true;
               opts.uploaded_filename = data.uploaded_filename || null;
               opts.uploadedFilename = data.uploaded_filename || null;
+              opts.num_pages = data.num_pages != null ? data.num_pages : null;
+              opts.numPages = data.num_pages != null ? data.num_pages : null;
             }
             applyLoadedMessages(messages, opts);
             refreshSaveLessonAvailability();
@@ -8783,6 +8833,21 @@ Last Updated: ${new Date().toLocaleDateString()}`;
             enableChatTab();
             showChatTab();
 
+            const pages = (data && (data.num_pages || data.pages || data.documents)) || Math.ceil(file.size / 50000);
+            currentPDFData = {
+              id: 'lesson_' + Date.now(),
+              title: inferredLessonName,
+              fileName: file.name,
+              fileSize: file.size,
+              context: context || '',
+              subject: '',
+              grade: '',
+              numPages: pages,
+              createdAt: new Date().toISOString(),
+              source: 'pdf_upload'
+            };
+            try { savePDFDataToStorage(); } catch (e) {}
+
             try {
               await loadChatHistoryFromBackend();
               await loadChatPromise(conversationId);
@@ -8790,27 +8855,24 @@ Last Updated: ${new Date().toLocaleDateString()}`;
               console.error('Error switching to new RAG conversation', e);
             }
 
-            // Now, inside the NEW conversation, show upload + context + success messages
+            // Preamble already shows PDF summary + action bullets; only add upload markers.
             addUserMessage(`📚 Uploading PDF: ${file.name} (${fileSizeMB} MB)`);
             if (context) {
               addUserMessage(`📝 Context: ${context}`);
             }
-            addAssistantMessage(`✅ Successfully uploaded and processed "${file.name}"!<br><br>
-            <strong>PDF Details:</strong><br>
-            • Size: ${fileSizeMB} MB<br>
-            • Pages: Estimated ${Math.ceil(file.size / 50000)} pages<br>
-            • Context: ${context || 'No specific context provided'}<br><br>
-            I can now answer questions based on this material. Try asking something like:<br>
-            • "Summarize the key concepts from this PDF"<br>
-            • "Create quiz questions from chapter 3"<br>
-            • "Explain the main topics in simple terms"`);
           } else {
             // Fallback: no conversation id returned – keep behavior local to current chat
             addUserMessage(`📚 Uploading PDF: ${file.name} (${fileSizeMB} MB)`);
             if (context) {
               addUserMessage(`📝 Context: ${context}`);
             }
-            addAssistantMessage('✅ PDF uploaded. You can now ask questions about this document.');
+            addAssistantMessage(buildPDFUploadSuccessMessage({
+              fileName: file.name,
+              lessonTitle: inferredLessonName,
+              lessonContext: context || '',
+              fileSize: file.size,
+              pages: Math.ceil(file.size / 50000)
+            }));
           }
         } catch (e) {
           console.error('RAG upload error', e);


### PR DESCRIPTION
## Summary
- Land students on **View and Manage Lesson** after login instead of an empty chat
- Remove duplicate **Create New Lesson** CTAs and redundant **View & Manage All Lessons** subtitle on the teacher dashboard
- Replace retired Groq `qwen/qwen3-32b` with `qwen/qwen3.6-27b`, clamp max completion tokens, and return PDF `num_pages` for teacher upload success UX

## Test plan
- [ ] Log in as student → confirm landing page is lessons list (not empty chat / welcome bubble)
- [ ] Open Ask Question from a lesson → chat still works; returning to lessons works
- [ ] Log in as teacher with no lessons → only one Create New Lesson button (sidebar); title is not duplicated with a subtitle
- [ ] Create lesson / upload PDF → auto-continue to chat and PDF summary bubble shows page count when available
- [ ] Admin/chat model list shows `qwen/qwen3.6-27b`; selecting old Qwen id remaps without Groq model_not_found