### PR TITLE
Fix PDF ingestion failing on embedded NUL bytes

### DIFF
--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1608,6 +1608,14 @@ def ingest_pdf(
                 f"PDF loaded with {loader_used} but contains no extractable text content.{scanned_hint}"
             )
 
+        # Some PDF parsers emit embedded NUL (0x00) bytes for certain fonts/encodings.
+        # PostgreSQL text columns reject NUL bytes outright, which previously caused
+        # ingestion to fail after embeddings were already computed. Strip them here,
+        # before splitting/embedding/export, so text stays consistent everywhere downstream.
+        for doc in docs:
+            if doc.page_content and "\x00" in doc.page_content:
+                doc.page_content = doc.page_content.replace("\x00", "")
+
         _send_progress("metadata", 30, "Adding metadata to pages...")
         ingest_page_label_map: Dict[int, int] = {}
         for i, doc in enumerate(docs):


### PR DESCRIPTION
## Summary
- PDF text extraction sometimes includes embedded NUL (0x00) bytes, which PostgreSQL rejects when storing RAG chunks.
- This caused ingestion to fail silently after embeddings were already computed, leaving `has_document=False` for the thread.
- Users then saw "Your PDF may still be processing" when trying to chat, even though ingestion had already permanently failed.
- Fix strips NUL bytes from extracted page text right after PDF parsing, before splitting/embedding/Postgres storage, so text stays consistent across markdown export, vector store, and DB.

## Root cause (from staging server logs)
```
ERROR: Failed to store chunks in PostgreSQL: A string literal cannot contain NUL (0x00) characters.
```
Recurred repeatedly on the staging ingest worker (`iqbal_ai_stg-celery_worker_ingest-1`).

## Test plan
- [ ] Upload a PDF known to contain embedded NUL bytes (or the one that previously failed on staging) and confirm ingestion succeeds and chat works.
- [ ] Upload a normal PDF and confirm no regression in ingestion/chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)