### PR TITLE
Reject unprocessable PDFs at upload time; warn on mixed text+image PDFs

### DIFF
--- a/app/routes/rag_routes.py
+++ b/app/routes/rag_routes.py
@@ -119,6 +119,95 @@ def _get_ingest_tier(file_size_mb: float) -> dict:
     }
 
 
+def _preflight_check_pdf(file_bytes: bytes, max_scan_pages: int = 25) -> dict:
+    """
+    Fast, synchronous check run at upload time, before the (potentially slow)
+    background ingestion is ever queued. Catches PDFs that can never be
+    ingested — corrupted files, password-protected files, and scanned/
+    image-only files with no selectable text — so the user is told
+    immediately, instead of the file being queued for background processing
+    and only failing later (which previously surfaced as a misleading
+    "PDF may still be processing" message when the user tried to chat).
+
+    Only scans the first `max_scan_pages` pages so this stays fast even for
+    large documents; the real ingestion step still processes every page.
+    """
+    import fitz  # PyMuPDF
+
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+    except Exception:
+        return {
+            'ok': False,
+            'code': 'PDF_UNREADABLE',
+            'message': (
+                'This file could not be opened as a PDF. It may be corrupted '
+                'or not actually a PDF file. Please check the file and upload it again.'
+            ),
+        }
+
+    try:
+        if doc.is_encrypted and not doc.authenticate(""):
+            return {
+                'ok': False,
+                'code': 'PDF_PASSWORD_PROTECTED',
+                'message': (
+                    'This PDF is password-protected. Please remove the password '
+                    'and upload it again.'
+                ),
+            }
+
+        if doc.page_count == 0:
+            return {
+                'ok': False,
+                'code': 'PDF_EMPTY',
+                'message': 'This PDF has no pages.',
+            }
+
+        has_text = False
+        has_images = False
+        for i, page in enumerate(doc):
+            if i >= max_scan_pages:
+                break
+            if not has_text and (page.get_text("text") or "").strip():
+                has_text = True
+            if not has_images and page.get_images():
+                has_images = True
+            if has_text and has_images:
+                break
+
+        if not has_text:
+            scanned_hint = (
+                " It looks like a scanned document (it contains images but no selectable text)."
+                if has_images else ""
+            )
+            return {
+                'ok': False,
+                'code': 'PDF_NO_TEXT',
+                'message': (
+                    f'This PDF has no readable text content.{scanned_hint} '
+                    'OCR support is required for scanned documents — please upload '
+                    'a PDF with real, selectable text instead.'
+                ),
+            }
+
+        return {'ok': True, 'has_images': has_images}
+    except Exception:
+        return {
+            'ok': False,
+            'code': 'PDF_UNREADABLE',
+            'message': (
+                'This file could not be read as a PDF. It may be corrupted. '
+                'Please check the file and upload it again.'
+            ),
+        }
+    finally:
+        try:
+            doc.close()
+        except Exception:
+            pass
+
+
 def _strip_lesson_finalization_from_response(text):
     """
     Remove internal lesson-finalization lines from AI response so they are never
@@ -443,6 +532,13 @@ def ingest():
         if not file_bytes:
             return jsonify({'error': 'File is empty'}), 400
 
+        # Reject PDFs that can never be ingested (corrupted, password-protected,
+        # or scanned/image-only with no selectable text) right now, instead of
+        # queuing them for background processing and only finding out later.
+        preflight = _preflight_check_pdf(file_bytes)
+        if not preflight['ok']:
+            return jsonify({'error': preflight['message'], 'code': preflight['code']}), 400
+
         # If streaming is requested, use SSE for backend processing progress (legacy support)
         if stream_progress:
             return _ingest_with_progress(
@@ -507,6 +603,7 @@ def ingest():
                     'chunks': result.get('chunks', 0),
                     'markdown_download_url': f'/api/rag/download-markdown/{thread_id}',
                     'processing_time_seconds': result.get('processing_time_seconds'),
+                    'warning': result.get('warning'),
                 })
             except ValueError as e:
                 logger.error(f"Value error in sync ingest: {str(e)}")
@@ -1626,6 +1723,7 @@ def get_ingest_status(task_id):
                 'chunks': result.get('chunks', 0),
                 'markdown_download_url': result.get('markdown_download_url') or (f'/api/rag/download-markdown/{thread_id}' if thread_id else None),
                 'processing_time_seconds': result.get('processing_time_seconds'),
+                'warning': result.get('warning'),
             }
         elif task.state == 'FAILURE':
             # Task failed

--- a/app/tasks/ingest_tasks.py
+++ b/app/tasks/ingest_tasks.py
@@ -75,6 +75,7 @@ def _run_ingest_in_context(self, file_path: str, thread_id: str, filename: str, 
         'chunks': result.get('chunks', 0),
         'markdown_download_url': f'/api/rag/download-markdown/{thread_id}',
         'processing_time_seconds': result.get('processing_time_seconds'),
+        'warning': result.get('warning'),
     }
 
 

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1608,6 +1608,28 @@ def ingest_pdf(
                 f"PDF loaded with {loader_used} but contains no extractable text content.{scanned_hint}"
             )
 
+        # If the document has both real text and embedded images, the text is
+        # still fully processed below, but flag it so the caller can warn the
+        # user that only the text was analyzed — any content that lives only
+        # in the images (diagrams, photos, scanned figures) was not.
+        mixed_content_warning = None
+        try:
+            import fitz  # PyMuPDF
+            pdf_doc = fitz.open(temp_path)
+            try:
+                has_images = any(
+                    len(page.get_images()) > 0 for page in list(pdf_doc)[:25]
+                )
+            finally:
+                pdf_doc.close()
+            if has_images:
+                mixed_content_warning = (
+                    "This PDF contains images as well as text. The text has been "
+                    "analyzed, but the images were not — ask about text content only."
+                )
+        except Exception as e:
+            logger.debug("Could not check for mixed text/image content: %s", e)
+
         # Some PDF parsers emit embedded NUL (0x00) bytes for certain fonts/encodings.
         # PostgreSQL text columns reject NUL bytes outright, which previously caused
         # ingestion to fail after embeddings were already computed. Strip them here,
@@ -1833,6 +1855,7 @@ def ingest_pdf(
             "ingest_profile": ingest_profile["name"],
             "file_size_mb": file_size_mb,
             "processing_time_seconds": _elapsed_seconds,
+            "warning": mixed_content_warning,
         }
 
     finally:

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -6026,7 +6026,10 @@ async function initializeApp() {
                             if (uploadBar) uploadBar.style.width = '100%';
                             if (uploadPercent) uploadPercent.textContent = '100%';
                             showNotification('PDF uploaded and processed successfully!', 'success');
-                            
+                            if (statusData.warning) {
+                                showNotification(statusData.warning, 'warning');
+                            }
+
                             // Hide progress and re-enable inputs
                             if (uploadProgress) uploadProgress.classList.add('hidden');
                             if (fileInput) fileInput.disabled = false;

--- a/templates/teacher_dashboard.html
+++ b/templates/teacher_dashboard.html
@@ -5539,6 +5539,9 @@
                 pendingConversationId = conversationId;
                 window._ingestPendingThreadId = pendingThreadId;
                 window._ingestCompletedSuccessfully = true;
+                if (statusData.warning) {
+                  showToast(statusData.warning, 'warning');
+                }
                 if (!window._createLessonMeta) window._createLessonMeta = {};
                 window._createLessonMeta.numPages = statusData.num_pages || statusData.pages || statusData.documents || null;
                 break;


### PR DESCRIPTION
## Summary
- Corrupted, password-protected, and scanned/image-only PDFs are now rejected **at upload time**, before background ingestion is ever queued. Previously they were queued, failed silently in the background, and the user only found out via a misleading "PDF may still be processing" message when trying to chat.
- PDFs containing both real text and images now ingest normally (text is fully processed), but the response includes a `warning` field telling the user only the text was analyzed, not the images. Both upload flows (chat sidebar upload, teacher "Create Lesson" upload) now surface this as a toast notification.

## Changes
- `app/routes/rag_routes.py`: new `_preflight_check_pdf()` helper (fast, bounded PyMuPDF scan of up to 25 pages), called right after the file is read in `/api/rag/ingest`, before any thread/Celery dispatch. Returns a specific `code`/`message` for `PDF_UNREADABLE`, `PDF_PASSWORD_PROTECTED`, `PDF_EMPTY`, `PDF_NO_TEXT`.
- `app/utils/rag_service.py`: `ingest_pdf()` now detects mixed text+image content and includes a `warning` string in its result dict.
- `app/tasks/ingest_tasks.py`: forwards `warning` through the Celery task result.
- `app/routes/rag_routes.py` (status endpoint + sync path): forwards `warning` into the JSON responses returned to the frontend.
- `templates/chat.html`, `templates/teacher_dashboard.html`: show `statusData.warning` as a toast notification on successful ingest.

## Test plan
- [ ] Upload a corrupted / truncated PDF — expect an immediate 400 at upload with a clear reason, no background task queued.
- [ ] Upload a password-protected PDF — expect immediate 400, "password-protected" message.
- [ ] Upload a scanned/image-only PDF — expect immediate 400, "scanned document" message.
- [ ] Upload a PDF containing both text and images — expect normal ingestion + a visible warning toast.
- [ ] Upload a normal text-only PDF — expect no warning, normal success flow (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)