### PR TITLE
Fix NUL-byte ingestion failure + reject unprocessable PDFs at upload time

### DIFF
--- a/app/routes/rag_routes.py
+++ b/app/routes/rag_routes.py
@@ -120,6 +120,95 @@ def _get_ingest_tier(file_size_mb: float) -> dict:
     }
 
 
+def _preflight_check_pdf(file_bytes: bytes, max_scan_pages: int = 25) -> dict:
+    """
+    Fast, synchronous check run at upload time, before the (potentially slow)
+    background ingestion is ever queued. Catches PDFs that can never be
+    ingested — corrupted files, password-protected files, and scanned/
+    image-only files with no selectable text — so the user is told
+    immediately, instead of the file being queued for background processing
+    and only failing later (which previously surfaced as a misleading
+    "PDF may still be processing" message when the user tried to chat).
+
+    Only scans the first `max_scan_pages` pages so this stays fast even for
+    large documents; the real ingestion step still processes every page.
+    """
+    import fitz  # PyMuPDF
+
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+    except Exception:
+        return {
+            'ok': False,
+            'code': 'PDF_UNREADABLE',
+            'message': (
+                'This file could not be opened as a PDF. It may be corrupted '
+                'or not actually a PDF file. Please check the file and upload it again.'
+            ),
+        }
+
+    try:
+        if doc.is_encrypted and not doc.authenticate(""):
+            return {
+                'ok': False,
+                'code': 'PDF_PASSWORD_PROTECTED',
+                'message': (
+                    'This PDF is password-protected. Please remove the password '
+                    'and upload it again.'
+                ),
+            }
+
+        if doc.page_count == 0:
+            return {
+                'ok': False,
+                'code': 'PDF_EMPTY',
+                'message': 'This PDF has no pages.',
+            }
+
+        has_text = False
+        has_images = False
+        for i, page in enumerate(doc):
+            if i >= max_scan_pages:
+                break
+            if not has_text and (page.get_text("text") or "").strip():
+                has_text = True
+            if not has_images and page.get_images():
+                has_images = True
+            if has_text and has_images:
+                break
+
+        if not has_text:
+            scanned_hint = (
+                " It looks like a scanned document (it contains images but no selectable text)."
+                if has_images else ""
+            )
+            return {
+                'ok': False,
+                'code': 'PDF_NO_TEXT',
+                'message': (
+                    f'This PDF has no readable text content.{scanned_hint} '
+                    'OCR support is required for scanned documents — please upload '
+                    'a PDF with real, selectable text instead.'
+                ),
+            }
+
+        return {'ok': True, 'has_images': has_images}
+    except Exception:
+        return {
+            'ok': False,
+            'code': 'PDF_UNREADABLE',
+            'message': (
+                'This file could not be read as a PDF. It may be corrupted. '
+                'Please check the file and upload it again.'
+            ),
+        }
+    finally:
+        try:
+            doc.close()
+        except Exception:
+            pass
+
+
 def _strip_lesson_finalization_from_response(text):
     """
     Remove internal lesson-finalization lines from AI response so they are never
@@ -444,6 +533,13 @@ def ingest():
         if not file_bytes:
             return jsonify({'error': 'File is empty'}), 400
 
+        # Reject PDFs that can never be ingested (corrupted, password-protected,
+        # or scanned/image-only with no selectable text) right now, instead of
+        # queuing them for background processing and only finding out later.
+        preflight = _preflight_check_pdf(file_bytes)
+        if not preflight['ok']:
+            return jsonify({'error': preflight['message'], 'code': preflight['code']}), 400
+
         # If streaming is requested, use SSE for backend processing progress (legacy support)
         if stream_progress:
             return _ingest_with_progress(
@@ -508,6 +604,7 @@ def ingest():
                     'chunks': result.get('chunks', 0),
                     'markdown_download_url': f'/api/rag/download-markdown/{thread_id}',
                     'processing_time_seconds': result.get('processing_time_seconds'),
+                    'warning': result.get('warning'),
                 })
             except ValueError as e:
                 logger.error(f"Value error in sync ingest: {str(e)}")
@@ -1627,6 +1724,7 @@ def get_ingest_status(task_id):
                 'chunks': result.get('chunks', 0),
                 'markdown_download_url': result.get('markdown_download_url') or (f'/api/rag/download-markdown/{thread_id}' if thread_id else None),
                 'processing_time_seconds': result.get('processing_time_seconds'),
+                'warning': result.get('warning'),
             }
         elif task.state == 'FAILURE':
             # Task failed

--- a/app/tasks/ingest_tasks.py
+++ b/app/tasks/ingest_tasks.py
@@ -75,6 +75,7 @@ def _run_ingest_in_context(self, file_path: str, thread_id: str, filename: str, 
         'chunks': result.get('chunks', 0),
         'markdown_download_url': f'/api/rag/download-markdown/{thread_id}',
         'processing_time_seconds': result.get('processing_time_seconds'),
+        'warning': result.get('warning'),
     }
 
 

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1607,6 +1607,28 @@ def ingest_pdf(
                 f"PDF loaded with {loader_used} but contains no extractable text content.{scanned_hint}"
             )
 
+        # If the document has both real text and embedded images, the text is
+        # still fully processed below, but flag it so the caller can warn the
+        # user that only the text was analyzed — any content that lives only
+        # in the images (diagrams, photos, scanned figures) was not.
+        mixed_content_warning = None
+        try:
+            import fitz  # PyMuPDF
+            pdf_doc = fitz.open(temp_path)
+            try:
+                has_images = any(
+                    len(page.get_images()) > 0 for page in list(pdf_doc)[:25]
+                )
+            finally:
+                pdf_doc.close()
+            if has_images:
+                mixed_content_warning = (
+                    "This PDF contains images as well as text. The text has been "
+                    "analyzed, but the images were not — ask about text content only."
+                )
+        except Exception as e:
+            logger.debug("Could not check for mixed text/image content: %s", e)
+
         # Some PDF parsers emit embedded NUL (0x00) bytes for certain fonts/encodings.
         # PostgreSQL text columns reject NUL bytes outright, which previously caused
         # ingestion to fail after embeddings were already computed. Strip them here,
@@ -1832,6 +1854,7 @@ def ingest_pdf(
             "ingest_profile": ingest_profile["name"],
             "file_size_mb": file_size_mb,
             "processing_time_seconds": _elapsed_seconds,
+            "warning": mixed_content_warning,
         }
 
     finally:

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1607,6 +1607,14 @@ def ingest_pdf(
                 f"PDF loaded with {loader_used} but contains no extractable text content.{scanned_hint}"
             )
 
+        # Some PDF parsers emit embedded NUL (0x00) bytes for certain fonts/encodings.
+        # PostgreSQL text columns reject NUL bytes outright, which previously caused
+        # ingestion to fail after embeddings were already computed. Strip them here,
+        # before splitting/embedding/export, so text stays consistent everywhere downstream.
+        for doc in docs:
+            if doc.page_content and "\x00" in doc.page_content:
+                doc.page_content = doc.page_content.replace("\x00", "")
+
         _send_progress("metadata", 30, "Adding metadata to pages...")
         ingest_page_label_map: Dict[int, int] = {}
         for i, doc in enumerate(docs):

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -6026,7 +6026,10 @@ async function initializeApp() {
                             if (uploadBar) uploadBar.style.width = '100%';
                             if (uploadPercent) uploadPercent.textContent = '100%';
                             showNotification('PDF uploaded and processed successfully!', 'success');
-                            
+                            if (statusData.warning) {
+                                showNotification(statusData.warning, 'warning');
+                            }
+
                             // Hide progress and re-enable inputs
                             if (uploadProgress) uploadProgress.classList.add('hidden');
                             if (fileInput) fileInput.disabled = false;

--- a/templates/teacher_dashboard.html
+++ b/templates/teacher_dashboard.html
@@ -5557,6 +5557,9 @@
                 pendingConversationId = conversationId;
                 window._ingestPendingThreadId = pendingThreadId;
                 window._ingestCompletedSuccessfully = true;
+                if (statusData.warning) {
+                  showToast(statusData.warning, 'warning');
+                }
                 if (!window._createLessonMeta) window._createLessonMeta = {};
                 window._createLessonMeta.numPages = statusData.num_pages || statusData.pages || statusData.documents || null;
                 break;


### PR DESCRIPTION
## Summary

Same two fixes already merged into `main` (via #118 and #119), ported onto `staging` since v2 development is happening there and these are real production-impacting bugs, not v1-specific.

### 1. NUL-byte ingestion failure (originally #118)
Some PDFs contain embedded NUL (0x00) bytes in extracted text, which PostgreSQL rejects when storing chunks. This silently failed ingestion after embeddings were already computed, leaving the thread stuck with no document — surfaced to users as a misleading "PDF may still be processing" message. Fix strips NUL bytes right after PDF text extraction, before splitting/embedding/storage.

### 2. Unprocessable PDFs now rejected at upload time (originally #119)
Corrupted, password-protected, and scanned/image-only PDFs were queued for background ingestion and only failed later — again surfacing as the same misleading "still processing" message. A fast synchronous check (`_preflight_check_pdf`, bounded to the first 25 pages) now rejects these immediately at upload, with a specific reason, before anything is queued.

PDFs containing both text and images now ingest normally (text is fully processed) but return a `warning` telling the user only the text was analyzed, not the images — surfaced as a toast on both upload flows (chat sidebar upload, teacher "Create Lesson" upload).

## Notes
- Cherry-picked cleanly from `main` with no conflicts (`app/utils/rag_service.py` had diverged meaningfully between `main` and `staging`, but both patches landed on unrelated lines).
- Verified with `python -m py_compile` on all three touched backend files.
- The NUL-byte fix was already re-tested live against a crafted NUL-byte PDF on the (main-based) production server and confirmed working end-to-end; the upload-time-validation fix is pending the same live re-test once merged.

## Test plan
- [ ] Upload a corrupted / truncated PDF — expect an immediate 400 at upload with a clear reason, no background task queued.
- [ ] Upload a password-protected PDF — expect immediate 400, "password-protected" message.
- [ ] Upload a scanned/image-only PDF — expect immediate 400, "scanned document" message.
- [ ] Upload a PDF containing both text and images — expect normal ingestion + a visible warning toast.
- [ ] Upload a PDF with an embedded NUL byte — expect successful ingestion and correct chat answers.
- [ ] Upload a normal text-only PDF — expect no warning, normal success flow (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)