### PR TITLE
Sanitize all invalid-UTF8 PDF text, timeout-guard preflight, fix rstrip bug

### DIFF
--- a/app/routes/rag_routes.py
+++ b/app/routes/rag_routes.py
@@ -120,7 +120,44 @@ def _get_ingest_tier(file_size_mb: float) -> dict:
     }
 
 
-def _preflight_check_pdf(file_bytes: bytes, max_scan_pages: int = 25) -> dict:
+def _preflight_check_pdf(file_bytes: bytes, max_scan_pages: int = 25, timeout_seconds: int = 15) -> dict:
+    """
+    Runs `_preflight_check_pdf_inner` with a hard wall-clock timeout.
+
+    PyMuPDF is a C extension: a malformed PDF can make it hang inside
+    `fz_open_document` with no Python-level exception to catch, which would
+    otherwise block the request thread forever. Running it in a daemon
+    thread with a bounded `.join()` means a hang costs one leaked thread
+    instead of an unresponsive request/worker.
+    """
+    import threading
+
+    box = {}
+
+    def _run():
+        box['result'] = _preflight_check_pdf_inner(file_bytes, max_scan_pages)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_seconds)
+
+    if t.is_alive():
+        return {
+            'ok': False,
+            'code': 'PDF_VALIDATION_TIMEOUT',
+            'message': (
+                'This PDF took too long to validate and may be malformed or '
+                'unusually complex. Please try a different file.'
+            ),
+        }
+    return box.get('result') or {
+        'ok': False,
+        'code': 'PDF_UNREADABLE',
+        'message': 'This file could not be validated. Please check the file and upload it again.',
+    }
+
+
+def _preflight_check_pdf_inner(file_bytes: bytes, max_scan_pages: int) -> dict:
     """
     Fast, synchronous check run at upload time, before the (potentially slow)
     background ingestion is ever queued. Catches PDFs that can never be
@@ -734,7 +771,13 @@ def download_markdown(thread_id):
     if not matches:
         return jsonify({'error': 'Markdown export not found for this document'}), 404
     md_path = matches[0]
-    download_name = (thread.filename or "document").rstrip(".pdf").rstrip(".PDF") or "document"
+    # NOTE: rstrip() strips a *character set*, not a suffix — e.g.
+    # "Chapter_1_pdf.pdf".rstrip(".pdf") wrongly yields "Chapter_1_".
+    # Strip the literal ".pdf"/".PDF" suffix instead.
+    download_name = thread.filename or "document"
+    if download_name.lower().endswith(".pdf"):
+        download_name = download_name[:-4]
+    download_name = download_name or "document"
     if not download_name.endswith(".md"):
         download_name += ".md"
     return send_file(

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1464,6 +1464,30 @@ def _get_retriever(thread_id: Optional[str], user_id: Optional[int] = None, step
     return VectorRetriever(thread_id, user_id, steps_list)
 
 
+def _sanitize_pdf_text(text: str) -> str:
+    """
+    Clean text extracted from a PDF so it can always be stored in PostgreSQL.
+
+    Two distinct problems show up here, both traced back to broken fonts/
+    encodings in the source PDF:
+    - Embedded NUL (0x00) bytes: valid in a Python str, but PostgreSQL text
+      columns reject them outright.
+    - Lone UTF-16 surrogates and other codepoints that are valid in a Python
+      str (PDF libraries sometimes use surrogateescape-style decoding on bad
+      byte sequences) but cannot be encoded to UTF-8 at all — PostgreSQL
+      raises "invalid byte sequence for encoding UTF8" on these too.
+    """
+    if not text:
+        return text
+    if "\x00" in text:
+        text = text.replace("\x00", "")
+    try:
+        text.encode("utf-8")
+    except UnicodeEncodeError:
+        text = text.encode("utf-8", errors="replace").decode("utf-8")
+    return text
+
+
 def ingest_pdf(
     file_bytes: bytes,
     thread_id: str,
@@ -1629,13 +1653,15 @@ def ingest_pdf(
         except Exception as e:
             logger.debug("Could not check for mixed text/image content: %s", e)
 
-        # Some PDF parsers emit embedded NUL (0x00) bytes for certain fonts/encodings.
-        # PostgreSQL text columns reject NUL bytes outright, which previously caused
-        # ingestion to fail after embeddings were already computed. Strip them here,
-        # before splitting/embedding/export, so text stays consistent everywhere downstream.
+        # Some PDF parsers emit embedded NUL (0x00) bytes, lone UTF-16 surrogates,
+        # or other invalid-for-UTF8 codepoints for certain fonts/broken encodings.
+        # PostgreSQL text columns reject all of these outright, which previously
+        # caused ingestion to fail after embeddings were already computed. Clean
+        # them here, before splitting/embedding/export, so text stays consistent
+        # everywhere downstream.
         for doc in docs:
-            if doc.page_content and "\x00" in doc.page_content:
-                doc.page_content = doc.page_content.replace("\x00", "")
+            if doc.page_content:
+                doc.page_content = _sanitize_pdf_text(doc.page_content)
 
         _send_progress("metadata", 30, "Adding metadata to pages...")
         ingest_page_label_map: Dict[int, int] = {}
@@ -1679,7 +1705,13 @@ def ingest_pdf(
             _save_logical_page_map_to_disk(thread_id_str, combined_logical_map)
 
         # Export extracted text as markdown for user download (## Page N + content per page)
-        safe_base = (safe_filename or "document").rstrip(".pdf").rstrip(".PDF") or "document"
+        # NOTE: rstrip() strips a *character set*, not a suffix — e.g.
+        # "Chapter_1_pdf.pdf".rstrip(".pdf") wrongly yields "Chapter_1_".
+        # Strip the literal ".pdf"/".PDF" suffix instead.
+        safe_base = safe_filename or "document"
+        if safe_base.lower().endswith(".pdf"):
+            safe_base = safe_base[:-4]
+        safe_base = safe_base or "document"
         md_filename = f"{thread_id_str}_{safe_base}.md"
         md_path = MARKDOWN_EXPORTS_DIR / md_filename
         md_parts = []


### PR DESCRIPTION
## Summary
Same fix as #121, ported onto \`staging\` (cherry-picked cleanly, no conflicts).

1. Broader text sanitization — round-trips extracted text through UTF-8 encode/decode, not just NUL-byte stripping, so lone surrogates and other invalid-for-UTF8 content from broken PDF fonts don't hit the same Postgres failure the NUL-byte bug did.
2. Upload-time preflight PDF check now runs in a daemon thread with a 15s timeout, since PyMuPDF can hang at the C level on malformed files with no Python exception to catch.
3. Fixed \`rstrip(".pdf")\` bug (strips a character set, not a suffix) in both locations — was corrupting markdown export/download filenames.

## Test plan
Same as #121 — filename edge case, NUL-byte regression, preflight-rejection regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)