### PR TITLE
Fix remaining PDF ingestion QA gaps (failure-state tracking, chunk caps, prompt-injection, table extraction)

### DIFF
--- a/app/models/database_models.py
+++ b/app/models/database_models.py
@@ -398,9 +398,18 @@ class RAGThread(Base):
     headings_ready = Column(Boolean, default=False, server_default='0')
     headings_count = Column(Integer, default=0, server_default='0')
     headings_last_scanned_at = Column(DateTime, nullable=True)
+    # Terminal ingestion state: 'pending' | 'processing' | 'success' | 'failed'.
+    # Lets the chat endpoint distinguish "still working" from "will never finish"
+    # instead of returning the same generic message for both.
+    ingest_status = Column(String(20), nullable=True)
+    ingest_error = Column(Text, nullable=True)
+    # Set to now()+time_limit when a Celery ingest task is queued. If a task is
+    # hard-killed (SIGKILL on Celery's time_limit) it never reaches its own
+    # except block, so this deadline is how we detect "abandoned" ingestion.
+    ingest_deadline_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, server_default=func.now())
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, server_default=func.now())
-    
+
     # Relationships
     user = relationship("User", back_populates="rag_threads")
     rag_prompts = relationship("RAGPrompt", back_populates="thread", cascade="all, delete-orphan")

--- a/app/routes/rag_routes.py
+++ b/app/routes/rag_routes.py
@@ -28,13 +28,14 @@ from langchain_core.messages import HumanMessage
 import logging
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 import re
 import json
 import time
 import base64
 import tempfile
+import zlib
 logger = logging.getLogger(__name__)
 bp = Blueprint('rag', __name__)
 _CANCELLED_UPLOAD_FILENAME = "__CANCELLED_UPLOAD__"
@@ -157,6 +158,56 @@ def _preflight_check_pdf(file_bytes: bytes, max_scan_pages: int = 25, timeout_se
     }
 
 
+_STREAM_START_RE = re.compile(rb'stream\r?\n')
+_MAX_BOMB_SCAN_STREAMS = 200
+
+
+def _check_decompression_bomb(file_bytes: bytes, max_output_mb: int = 60) -> str:
+    """
+    Cheap pre-scan for PDF decompression bombs: a FlateDecode stream that
+    expands far beyond anything a legitimate single PDF stream (a page's
+    content, one embedded font, one image) should ever need. Runs on the
+    raw bytes before fitz/pypdf ever open the file, so a bomb is rejected
+    before paying the cost of fully decompressing it.
+
+    Scoped to FlateDecode, the overwhelmingly common PDF compression
+    filter — other filters still fall back on the existing 100 MB total
+    upload-size cap. Returns an error message string, or '' if clean.
+    """
+    max_output_bytes = max_output_mb * 1024 * 1024
+    scanned = 0
+    for match in _STREAM_START_RE.finditer(file_bytes):
+        if scanned >= _MAX_BOMB_SCAN_STREAMS:
+            break
+        start = match.end()
+        end = file_bytes.find(b'endstream', start)
+        if end == -1:
+            continue
+        raw = file_bytes[start:end]
+        scanned += 1
+        if len(raw) < 256:
+            continue  # too small to be a bomb
+        try:
+            decompressor = zlib.decompressobj()
+            out_len = 0
+            out = decompressor.decompress(raw, max_output_bytes + 1)
+            out_len += len(out)
+            while decompressor.unconsumed_tail and out_len <= max_output_bytes:
+                out = decompressor.decompress(decompressor.unconsumed_tail, max_output_bytes + 1 - out_len)
+                if not out:
+                    break
+                out_len += len(out)
+            if out_len > max_output_bytes:
+                return (
+                    f"This PDF contains a compressed stream that expands to over {max_output_mb} MB "
+                    "when decompressed, which is far larger than any normal document needs. It was "
+                    "rejected to protect server memory — please upload a different file."
+                )
+        except zlib.error:
+            continue  # not a zlib stream at this offset — not what we're checking for
+    return ''
+
+
 def _preflight_check_pdf_inner(file_bytes: bytes, max_scan_pages: int) -> dict:
     """
     Fast, synchronous check run at upload time, before the (potentially slow)
@@ -171,6 +222,10 @@ def _preflight_check_pdf_inner(file_bytes: bytes, max_scan_pages: int) -> dict:
     large documents; the real ingestion step still processes every page.
     """
     import fitz  # PyMuPDF
+
+    bomb_message = _check_decompression_bomb(file_bytes)
+    if bomb_message:
+        return {'ok': False, 'code': 'PDF_TOO_COMPLEX', 'message': bomb_message}
 
     try:
         doc = fitz.open(stream=file_bytes, filetype="pdf")
@@ -657,7 +712,8 @@ def ingest():
         # resolution is available immediately even if worker-side DB flag update
         # is delayed or transiently fails under load.
         try:
-            _save_thread_to_db(user_id, thread_id, filename, ingest_result=None)
+            _ingest_deadline = datetime.utcnow() + timedelta(seconds=ingest_tier["time_limit"] + 60)
+            _save_thread_to_db(user_id, thread_id, filename, ingest_result=None, ingest_deadline_at=_ingest_deadline)
         except Exception:
             logger.warning("Failed to precreate thread row for thread_id=%s", thread_id, exc_info=True)
 
@@ -788,8 +844,22 @@ def download_markdown(thread_id):
     )
 
 
-def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_result: dict = None):
-    """Save or update RAG thread in database. On success, set has_document, doc_count, num_pages."""
+def _save_thread_to_db(
+    user_id: int,
+    thread_id: str,
+    filename: str,
+    ingest_result: dict = None,
+    ingest_deadline_at=None,
+    ingest_error: str = None,
+):
+    """
+    Save or update RAG thread in database. On success, set has_document, doc_count, num_pages.
+
+    ingest_status transitions:
+      - precreate (no ingest_result, no ingest_error): 'processing', deadline set from ingest_deadline_at
+      - success (ingest_result provided): 'success'
+      - failure (ingest_error provided): 'failed', error message stored for the chat endpoint to surface
+    """
     db = get_db()
     try:
         existing_thread = db.query(RAGThread).filter_by(thread_id=thread_id).first()
@@ -810,7 +880,13 @@ def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_resul
             existing_thread = rag_thread
             logger.info("Created new thread %s for user %s", thread_id, user_id)
 
-        if ingest_result:
+        if ingest_error:
+            existing_thread.ingest_status = 'failed'
+            existing_thread.ingest_error = ingest_error[:2000]
+            existing_thread.updated_at = now
+            db.commit()
+            logger.info("Marked thread %s as failed: %s", thread_id, ingest_error[:200])
+        elif ingest_result:
             existing_thread.filename = filename
             existing_thread.has_document = True
             existing_thread.doc_count = (existing_thread.doc_count or 0) + 1
@@ -818,12 +894,17 @@ def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_resul
             existing_thread.last_ingested_at = now
             existing_thread.embedding_model = ingest_result.get("embedding_model")
             existing_thread.embedding_dim = ingest_result.get("embedding_dim")
+            existing_thread.ingest_status = 'success'
+            existing_thread.ingest_error = None
             existing_thread.updated_at = now
             db.commit()
             logger.info("Updated thread %s with has_document=true, doc_count=%s", thread_id, existing_thread.doc_count)
         else:
             if not existing_thread.has_document:
                 existing_thread.filename = filename
+                existing_thread.ingest_status = 'processing'
+                if ingest_deadline_at:
+                    existing_thread.ingest_deadline_at = ingest_deadline_at
                 existing_thread.updated_at = now
                 db.commit()
     except Exception as e:
@@ -1254,6 +1335,28 @@ def chat():
                         'thread_id': thread_id
                     }), 400
             else:
+                # Distinguish a genuinely-still-running ingest from one that
+                # already failed (explicit failure) or was abandoned (worker
+                # hard-killed on Celery's time_limit, so its except block
+                # never ran) — instead of returning the same "still processing"
+                # message for all three, which used to hide permanent failures
+                # forever.
+                ingest_status = getattr(thread_row, 'ingest_status', None)
+                deadline = getattr(thread_row, 'ingest_deadline_at', None)
+                if ingest_status == 'failed':
+                    logger.warning("RAG chat 400: thread_id=%s ingestion failed: %s", thread_id, thread_row.ingest_error)
+                    return jsonify({
+                        'error': f"PDF processing failed: {thread_row.ingest_error or 'unknown error'}. Please upload the document again.",
+                        'code': 'INGEST_FAILED',
+                        'thread_id': thread_id
+                    }), 400
+                if deadline and datetime.utcnow() > deadline:
+                    logger.warning("RAG chat 400: thread_id=%s ingestion abandoned past deadline=%s", thread_id, deadline)
+                    return jsonify({
+                        'error': 'PDF processing took too long and did not complete. Please upload the document again.',
+                        'code': 'INGEST_TIMEOUT',
+                        'thread_id': thread_id
+                    }), 400
                 logger.warning("RAG chat 400: Thread exists but has_document=False and no chunks thread_id=%s", thread_id)
                 return jsonify({
                     'error': 'Your PDF may still be processing. Please wait a moment and try again, or upload the PDF again.',

--- a/app/tasks/ingest_tasks.py
+++ b/app/tasks/ingest_tasks.py
@@ -94,6 +94,7 @@ def ingest_pdf_task(self, file_path: str, thread_id: str, filename: str, user_id
             state='FAILURE',
             meta={'error': error_msg, 'message': f'Validation error: {error_msg}', 'exc_type': 'ValueError', 'exc_message': error_msg}
         )
+        _save_thread_to_db(user_id, thread_id, filename, ingest_error=error_msg)
         return {'success': False, 'error': error_msg, 'message': f'Validation error: {error_msg}'}
     except Exception as e:
         error_msg = f'Failed to ingest PDF: {str(e)}'
@@ -103,10 +104,11 @@ def ingest_pdf_task(self, file_path: str, thread_id: str, filename: str, user_id
             state='FAILURE',
             meta={'error': error_msg, 'message': error_msg, 'exc_type': exc_type, 'exc_message': str(e)}
         )
+        _save_thread_to_db(user_id, thread_id, filename, ingest_error=error_msg)
         return {'success': False, 'error': error_msg, 'message': error_msg, 'exc_type': exc_type}
 
 
-def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_result: dict = None):
+def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_result: dict = None, ingest_error: str = None):
     """
     Helper function to save thread to database.
     Uses the shared SQLAlchemy session factory via get_db(), which is already
@@ -155,7 +157,13 @@ def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_resul
             existing_thread = rag_thread
             logger.info("Created new thread %s for user %s", thread_id, user_id)
 
-        if ingest_result:
+        if ingest_error:
+            existing_thread.ingest_status = 'failed'
+            existing_thread.ingest_error = ingest_error[:2000]
+            existing_thread.updated_at = now
+            db.commit()
+            logger.info("Marked thread %s as failed: %s", thread_id, ingest_error[:200])
+        elif ingest_result:
             existing_thread.filename = filename
             existing_thread.has_document = True
             existing_thread.doc_count = (existing_thread.doc_count or 0) + 1
@@ -163,6 +171,8 @@ def _save_thread_to_db(user_id: int, thread_id: str, filename: str, ingest_resul
             existing_thread.last_ingested_at = now
             existing_thread.embedding_model = ingest_result.get("embedding_model")
             existing_thread.embedding_dim = ingest_result.get("embedding_dim")
+            existing_thread.ingest_status = 'success'
+            existing_thread.ingest_error = None
             existing_thread.updated_at = now
             db.commit()
             logger.info("Updated thread %s with has_document=true", thread_id)

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -357,6 +357,24 @@ def init_db(app):
                 logger.warning(f"Subscription migration warning: {str(e)}")
                 db.rollback()
             
+            # Migration: Add ingest failure-tracking columns to rag_threads
+            try:
+                db = get_db()
+                inspector = inspect(engine)
+                if 'rag_threads' in inspector.get_table_names():
+                    columns = [col['name'] for col in inspector.get_columns('rag_threads')]
+                    if 'ingest_status' not in columns:
+                        logger.info("Adding ingest_status/ingest_error/ingest_deadline_at columns to rag_threads table...")
+                        db.execute(text("ALTER TABLE rag_threads ADD COLUMN ingest_status VARCHAR(20)"))
+                        db.execute(text("ALTER TABLE rag_threads ADD COLUMN ingest_error TEXT"))
+                        db.execute(text("ALTER TABLE rag_threads ADD COLUMN ingest_deadline_at TIMESTAMP"))
+                        db.execute(text("UPDATE rag_threads SET ingest_status = 'success' WHERE has_document = TRUE"))
+                        db.commit()
+                        logger.info("rag_threads ingest-tracking columns added successfully")
+            except Exception as e:
+                logger.warning(f"rag_threads ingest-tracking migration warning: {str(e)}")
+                db.rollback()
+
             # Run RAG migration (add new columns, create rag_chunks table)
             try:
                 import sys

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -300,7 +300,11 @@ def _resolve_ingest_profile(file_size_mb: float) -> dict:
         "name": "standard",
         "chunk_size": int(os.getenv("RAG_STANDARD_CHUNK_SIZE", "2200")),
         "chunk_overlap": int(os.getenv("RAG_STANDARD_CHUNK_OVERLAP", "300")),
-        "max_chunks": int(os.getenv("RAG_STANDARD_MAX_CHUNKS", "0")),
+        # File size is not a proxy for page/chunk count (a 2 MB, 4000-page PDF
+        # is "standard" tier by size but produces as many chunks as a huge
+        # scanned document). Cap it like the large tier instead of leaving it
+        # unbounded just because the file happens to be under the size threshold.
+        "max_chunks": int(os.getenv("RAG_STANDARD_MAX_CHUNKS", "2000")),
         "retrieval_k": int(os.getenv("RAG_STANDARD_RETRIEVAL_K", "6")),
         "threshold_mb": threshold_mb,
     }
@@ -1679,6 +1683,7 @@ def ingest_pdf(
         # user that only the text was analyzed — any content that lives only
         # in the images (diagrams, photos, scanned figures) was not.
         mixed_content_warning = None
+        invisible_text_hits = 0
         try:
             import fitz  # PyMuPDF
             pdf_doc = fitz.open(temp_path)
@@ -1686,6 +1691,37 @@ def ingest_pdf(
                 has_images = any(
                     len(page.get_images()) > 0 for page in list(pdf_doc)[:25]
                 )
+
+                # Strip text rendered with the PDF "invisible" render mode
+                # (Tr 3 — PDF spec 9.3.3). This is a known indirect
+                # prompt-injection vector: content invisible to the
+                # uploading teacher (white-on-white, zero-opacity, or an
+                # explicit invisible render mode) is extracted by every
+                # text loader exactly like visible content and would
+                # otherwise end up verbatim in the retrieval corpus.
+                for page_index, page in enumerate(pdf_doc):
+                    if page_index >= len(docs):
+                        break
+                    try:
+                        traces = page.get_texttrace()
+                    except Exception:
+                        continue
+                    invisible_strings = []
+                    for trace in traces:
+                        if trace.get('type') in (3, 7):  # invisible / invisible+clip
+                            chars = trace.get('chars') or []
+                            hidden_text = ''.join(
+                                chr(c[0]) for c in chars if c and c[0]
+                            )
+                            if hidden_text.strip():
+                                invisible_strings.append(hidden_text)
+                    if invisible_strings and docs[page_index].page_content:
+                        content = docs[page_index].page_content
+                        for hidden_text in invisible_strings:
+                            if hidden_text in content:
+                                content = content.replace(hidden_text, ' ')
+                                invisible_text_hits += 1
+                        docs[page_index].page_content = content
             finally:
                 pdf_doc.close()
             if has_images:
@@ -1695,6 +1731,13 @@ def ingest_pdf(
                 )
         except Exception as e:
             logger.debug("Could not check for mixed text/image content: %s", e)
+
+        if invisible_text_hits:
+            logger.warning(
+                "Stripped invisible/hidden PDF text at %d location(s) for thread %s "
+                "(filename=%s) — possible indirect prompt-injection via invisible text.",
+                invisible_text_hits, thread_id_str, filename,
+            )
 
         # Some PDF parsers emit embedded NUL (0x00) bytes, lone UTF-16 surrogates,
         # or other invalid-for-UTF8 codepoints for certain fonts/broken encodings.
@@ -1746,6 +1789,54 @@ def ingest_pdf(
         if combined_logical_map:
             _cache_thread_page_label_map(thread_id_str, combined_logical_map)
             _save_logical_page_map_to_disk(thread_id_str, combined_logical_map)
+
+        # Tables extracted by PyPDFLoader/PyMuPDFLoader come back as a flat
+        # run of tokens with no row/column relationship (e.g. a grade table
+        # becomes "Student Math Physics ... Ali 61 86 67 Sara 88 ..." with no
+        # way to tell which score belongs to which subject). PDFPlumber is
+        # the one loader in the fallback chain that understands tables, but
+        # it's normally only reached when the primary loaders fail outright
+        # — which they don't here, since the flattened text is non-empty.
+        # So: independently detect tables with pdfplumber and append a
+        # markdown-formatted version alongside the existing flattened text,
+        # regardless of which loader produced the page. This does duplicate
+        # the raw numbers in the chunk, but gives the model a structured
+        # version it can actually read correctly.
+        if PDFPLUMBER_AVAILABLE:
+            try:
+                import pdfplumber
+                with pdfplumber.open(temp_path) as plumber_pdf:
+                    for page_index, plumber_page in enumerate(plumber_pdf.pages):
+                        if page_index >= len(docs):
+                            break
+                        try:
+                            tables = plumber_page.extract_tables()
+                        except Exception:
+                            continue
+                        if not tables:
+                            continue
+                        table_blocks = []
+                        for table in tables:
+                            rows = [r for r in table if r and any((c or "").strip() for c in r)]
+                            if len(rows) < 2:
+                                continue
+                            header, body_rows = rows[0], rows[1:]
+                            header_cells = [(c or "").strip() for c in header]
+                            lines = [
+                                "| " + " | ".join(header_cells) + " |",
+                                "| " + " | ".join(["---"] * len(header_cells)) + " |",
+                            ]
+                            for row in body_rows:
+                                cells = [(c or "").strip() for c in row]
+                                if len(cells) < len(header_cells):
+                                    cells += [""] * (len(header_cells) - len(cells))
+                                lines.append("| " + " | ".join(cells[:len(header_cells)]) + " |")
+                            table_blocks.append("\n".join(lines))
+                        if table_blocks:
+                            addendum = "\n\n[Table data, extracted with row/column structure]\n" + "\n\n".join(table_blocks)
+                            docs[page_index].page_content = (docs[page_index].page_content or "") + addendum
+            except Exception as e:
+                logger.debug("Could not run table-aware extraction pass: %s", e)
 
         # Export extracted text as markdown for user download (## Page N + content per page)
         # NOTE: rstrip() strips a *character set*, not a suffix — e.g.

--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -1657,6 +1657,26 @@ def ingest_pdf(
         _send_progress("validating", 25, f"Validating {num_pages} pages (loaded with {loader_used})...")
 
         valid_pages = [d for d in docs if d.page_content and d.page_content.strip()]
+
+        # A loader recovering *some* pages from a truncated/corrupted file
+        # (common with PyMuPDF's repair) previously reported full success —
+        # num_pages matched the structural page count, chunks got created
+        # from whatever text survived, and nothing indicated most of the
+        # document never actually made it in. Flag it instead of staying
+        # silent whenever a large share of pages came back with no text at
+        # all (a lone blank page — a cover, a divider — is normal and not
+        # worth warning about).
+        partial_content_warning = None
+        if len(valid_pages) < num_pages:
+            missing_page_count = num_pages - len(valid_pages)
+            if missing_page_count / num_pages >= 0.3:
+                partial_content_warning = (
+                    f"Only {len(valid_pages)} of {num_pages} pages in this PDF had readable text — "
+                    f"the other {missing_page_count} came back empty. This can happen with a damaged, "
+                    "truncated, or partially corrupted file, so the document may be missing content. "
+                    "If answers seem incomplete, try re-exporting or re-uploading the original file."
+                )
+
         if len(valid_pages) == 0:
             # Check if PDF might be scanned (image-based)
             scanned_hint = ""
@@ -2007,6 +2027,8 @@ def ingest_pdf(
         _elapsed_seconds = round(time.time() - _start_time, 2)
         _send_progress("complete", 100, f"PDF processing complete! Processed {num_pages} pages in {_elapsed_seconds}s.")
 
+        combined_warning = " ".join(w for w in (partial_content_warning, mixed_content_warning) if w) or None
+
         return {
             "thread_id": thread_id_str,
             "filename": filename or safe_filename,
@@ -2020,7 +2042,7 @@ def ingest_pdf(
             "ingest_profile": ingest_profile["name"],
             "file_size_mb": file_size_mb,
             "processing_time_seconds": _elapsed_seconds,
-            "warning": mixed_content_warning,
+            "warning": combined_warning,
         }
 
     finally:


### PR DESCRIPTION
## Summary

Fixes the remaining open items from the full PDF-ingestion QA sweep (25-item bug list, tested live against staging across 3 regression rounds).

- **rag_threads failure-state tracking**: adds `ingest_status`/`ingest_error`/`ingest_deadline_at` so a failed or abandoned (Celery hard-timeout-killed) ingest is reported distinctly to the chat endpoint instead of the generic "may still be processing" message forever.
- **Unbounded chunk count**: the standard ingest tier had no chunk cap (only the >40MB "large" tier did), so small-but-many-page files could produce unbounded chunks. Now capped.
- **Hidden-text prompt-injection vector**: strips PDF text rendered with the invisible render mode (`Tr 3`) before embedding — previously hidden instructions were extracted and stored identically to visible content.
- **Decompression-bomb guard**: cheap pre-scan rejects FlateDecode streams that decompress far beyond any legitimate single PDF stream, before fitz/pypdf ever open the file.
- **Table extraction**: appends a markdown-formatted table (via pdfplumber) alongside the existing flattened text when a page contains a table, so structure isn't lost.
- **Truncated/corrupted PDF partial-recovery warning**: a loader repairing a damaged file (PyMuPDF's repair kicks in on truncated PDFs) previously reported full success as long as one page had text. Now warns whenever 30%+ of pages come back with no extractable text at all.

## Test plan
- [x] Live-tested against staging (209.23.12.180) across 3 full regression rounds with a battery of edge-case PDFs (encrypted, corrupted, decompression bombs, hidden-text injection, tables, truncated files, mixed content, multi-column, ligatures, etc.)
- [x] All 6 fixes verified fixed with before/after evidence; 0 regressions across the 3 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)