### PR TITLE
Fix math rendering: no-PDF chats get no delimiter instructions, fallback misses multi-line/paren math

### DIFF
--- a/app/utils/rag_service.py
+++ b/app/utils/rag_service.py
@@ -4085,7 +4085,13 @@ def _chat_build_system_message(
                     _get_stored_rag_system_template(RAG_SYSTEM_SETTING_KEY_NO_PDF)
                     or DEFAULT_RAG_CHAT_SYSTEM_BODY_NO_PDF
                 )
-            system_message = SystemMessage(content=no_pdf_body)
+            # Every other branch (with-document, and no-document-with-custom-prompt above)
+            # appends RAG_REPLY_FORMATTING_INSTRUCTIONS - this branch previously didn't, so a
+            # plain question asked with no PDF uploaded got zero math-delimiter guidance and the
+            # model free-styled with bare [...]/(...)  instead of \( \)/\[ \].
+            system_message = SystemMessage(
+                content=f"{no_pdf_body}\n\n---\n\n{RAG_REPLY_FORMATTING_INSTRUCTIONS}"
+            )
 
     # Progressive message reduction on token errors
     raw_messages = state.get("messages", []) or []

--- a/static/teacher/js/chat-response-formatter.js
+++ b/static/teacher/js/chat-response-formatter.js
@@ -72,16 +72,32 @@
    * like LaTeX (backslash commands, ^{}, _{}) and convert them to \[ ... \]. Deliberately does
    * NOT touch markdown links "[text](url)" or reference-style definitions "[id]: url".
    */
+  function _looksLikeMath(inner) {
+    return /\\(text|frac|sqrt|sum|int|alpha|beta|gamma|theta|pi|pm|times|cdot|leq|geq|neq|approx|left|right|begin|end|overline|infty|partial|Delta|delta)\b/.test(inner)
+      || /\^\{|_\{|\\[a-zA-Z]+\{/.test(inner)
+      // Bare exponents with no LaTeX commands at all, e.g. "ax^2 + bx + c = 0" - the model
+      // sometimes writes plain-notation equations without a single backslash command.
+      || /[a-zA-Z0-9]\^-?\d/.test(inner);
+  }
+
   function convertBareBracketMathToLatex(str) {
     if (!str || typeof str !== 'string') return str;
-    return str.replace(/\[([^\[\]\n]{1,400})\]/g, function (match, inner, offset, full) {
+    // Square brackets: [\s\S] (not just non-newline) so multi-line display math like
+    // "[\nax^2 + bx + c = 0\n]" (model wrote bare brackets across several lines) is also
+    // caught, not just the single-line case.
+    str = str.replace(/\[([\s\S]{1,400}?)\]/g, function (match, inner, offset, full) {
       var after = full.slice(offset + match.length, offset + match.length + 1);
       if (after === '(' || after === ':') return match;
-      var looksLikeMath = /\\(text|frac|sqrt|sum|int|alpha|beta|gamma|theta|pi|pm|times|cdot|leq|geq|neq|approx|left|right|begin|end|overline|infty|partial|Delta|delta)\b/.test(inner)
-        || /\^\{|_\{|\\[a-zA-Z]+\{/.test(inner);
-      if (!looksLikeMath) return match;
+      if (!_looksLikeMath(inner)) return match;
       return '\\[ ' + inner.trim() + ' \\]';
     });
+    // Bare parens containing LaTeX markup, e.g. "(a \neq 0)" instead of "\(a \neq 0\)".
+    // Negative lookbehind excludes '(' that is already part of a correct "\(" delimiter.
+    str = str.replace(/(?<!\\)\(([^()]{1,200})\)/g, function (match, inner) {
+      if (!_looksLikeMath(inner)) return match;
+      return '\\(' + inner.trim() + '\\)';
+    });
+    return str;
   }
 
   /**

--- a/static/teacher/js/chat-response-formatter.js
+++ b/static/teacher/js/chat-response-formatter.js
@@ -84,8 +84,11 @@
     if (!str || typeof str !== 'string') return str;
     // Square brackets: [\s\S] (not just non-newline) so multi-line display math like
     // "[\nax^2 + bx + c = 0\n]" (model wrote bare brackets across several lines) is also
-    // caught, not just the single-line case.
-    str = str.replace(/\[([\s\S]{1,400}?)\]/g, function (match, inner, offset, full) {
+    // caught, not just the single-line case. (?<!\\) excludes '[' that is already part of
+    // a correct "\[" delimiter - without this guard, an already-valid multi-line "\[ ... \]"
+    // block (very common - the model often puts the delimiters on their own lines) gets
+    // matched and double-wrapped into broken "\\[ ... \]" text instead of being left alone.
+    str = str.replace(/(?<!\\)\[([\s\S]{1,400}?)\]/g, function (match, inner, offset, full) {
       var after = full.slice(offset + match.length, offset + match.length + 1);
       if (after === '(' || after === ':') return match;
       if (!_looksLikeMath(inner)) return match;


### PR DESCRIPTION
## Summary

Live bug reported with a screenshot from staging: a chat with **no PDF uploaded** showed raw, unrendered LaTeX — `[ax^2 + bx + c = 0]` and `(a \neq 0)` as literal text instead of typeset equations. This is a follow-up fix to PR #125's math-delimiter work, which only covered the with-PDF path.

**Root cause 1 (backend)**: `_chat_build_system_message`'s no-document branch built the system message straight from `DEFAULT_RAG_CHAT_SYSTEM_BODY_NO_PDF`, never appending `RAG_REPLY_FORMATTING_INSTRUCTIONS` (where the `\( \)`/`\[ \]` mandate lives) — every other branch (with-document, and no-document-with-custom-prompt) already did this. My prior testing pass only exercised the with-PDF lecture flow and missed this gap.

**Root cause 2 (frontend defense-in-depth)**: `convertBareBracketMathToLatex`'s bracket regex excluded newlines, so multi-line display math like `[\nax^2 + bx + c = 0\n]` never matched; it also only handled square brackets, not bare parens like `(a \neq 0)`. The math-content heuristic also missed bare exponents (`ax^2`) with no LaTeX commands at all — the exact pattern the model actually produced.

Verified the exact reported text against the new regex logic with a standalone Node script before deploying (not just source-pattern assertions).

## Test plan
- [x] 15 static tests pass (3 new, covering the no-PDF branch and both frontend gaps)
- [x] Full suite: 114/120 pass, same 6 pre-existing unrelated failures as before, no new regressions
- [x] Verified with Node against the exact screenshot text: both the multi-line display equation and the bare-paren inequality now convert correctly; markdown links, plain English parens, and already-correct `\( \)` are left untouched
- [ ] Deploying to staging server now for live confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)